### PR TITLE
fix: add unique key field for comments

### DIFF
--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -11,6 +11,7 @@ const args = arg({
   '--owner': String,
   '--repo': String,
   '--title': String,
+  '--key': String,
 
   '--help': Boolean,
   '--verbose': Boolean,
@@ -34,7 +35,8 @@ if (args['--help']) {
     --pr           Number     :    The pull request/issue to comment on. Detected in CI env
     --owner        String     :    The owner for the project. Detected in CI env
     --repo         String     :    The repo for the project. Detected in CI env
-    --title        String     :    The title to key your comment with. Defaults to "commently"
+    --title        String     :    The title to your comment with. Defaults to "Commently"
+    --key        String     :    The unique key to id your comment with. Defaults to "commently"
     --help, -h     Boolean    :    Show the help dialog
     --verbose, -v  Boolean    :    Output the debug log
   `);
@@ -53,7 +55,8 @@ const commently = new Commently({
   pr: args['--pr'],
   owner: args['--owner'],
   repo: args['--repo'],
-  title: args['--title']
+  title: args['--title'],
+  key: args['--key']
 });
 
 commently

--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -36,7 +36,7 @@ if (args['--help']) {
     --owner        String     :    The owner for the project. Detected in CI env
     --repo         String     :    The repo for the project. Detected in CI env
     --title        String     :    The title to your comment with. Defaults to "Commently"
-    --key        String     :    The unique key to id your comment with. Defaults to "commently"
+    --key          String     :    The unique key to id your comment with. Usually the name of the bot. Defaults to "commently"
     --help, -h     Boolean    :    Show the help dialog
     --verbose, -v  Boolean    :    Output the debug log
   `);

--- a/packages/core/core.ts
+++ b/packages/core/core.ts
@@ -7,6 +7,8 @@ interface CommentlyArgs {
   owner?: string;
   repo?: string;
   title?: string;
+  // They unique key to identify the comment by, not shown to end users
+  key?: string;
 }
 
 interface EnvCi {
@@ -26,6 +28,7 @@ export default class Commently {
   private readonly owner: string;
   private readonly repo: string;
   private readonly title: string;
+  private readonly key: string;
   private readonly issueId: number;
   private readonly footer: string;
   private readonly delim: string;
@@ -44,7 +47,8 @@ export default class Commently {
       );
     }
 
-    this.title = args.title || 'commently';
+    this.title = args.title || '';
+    this.key = args.key || 'commently';
     this.owner = args.owner || owner;
     this.repo = args.repo || repo;
 
@@ -61,13 +65,13 @@ export default class Commently {
     }
 
     this.issueId = prNumber;
-    this.header = `<!-- \n ${this.title}-id: ${this.issueId} \n -->\n${
+    this.header = `<!-- \n ${this.key}-id: ${this.issueId} \n -->\n${
       this.title
     }\n`;
     this.footer = `Courtesy of your **[${
-      this.title
+      this.key
     }](https://github.com/intuit/commently)** bot :package::rocket:`;
-    this.delim = `<!-- ${this.title}-section -->\n\n`;
+    this.delim = `<!-- ${this.key}-section -->\n\n`;
 
     this.debug('Initialized: owner=%s repo=%s', this.owner, this.repo);
 
@@ -101,7 +105,7 @@ export default class Commently {
     append = true
   ) {
     this.debug('Editing existing Keyed Comment. id=%s', comment.id);
-    const historyDelim = `<!-- ${this.title}-history -->`;
+    const historyDelim = `<!-- ${this.key}-history -->`;
 
     if (append) {
       const parts = comment.body.split(this.delim);


### PR DESCRIPTION
<!-- # PR Template

Thank you for contributing!

-->

## What does this change do and why

Closes #31

Allows a user to provide a unique key to identify the
comment by that isn't the title.